### PR TITLE
Upgrade kit on nostalgia maps

### DIFF
--- a/dtcm/standard/airship_aces/map.xml
+++ b/dtcm/standard/airship_aces/map.xml
@@ -2,7 +2,7 @@
 <map proto="1.3.2">
 <include src="tutorial.xml"/>
 <name>Airship Aces</name>
-<version>1.2.6</version>
+<version>1.2.7</version>
 <objective>Leak lava into the void below to win!</objective>
 <rules>
     <rule>Players have resistance and reduced knockback in spawn!</rule>
@@ -29,7 +29,7 @@
         <item slot="28" amount="64">arrow</item>
         <item slot="2">diamond pickaxe</item>
         <item slot="3">diamond axe</item>
-        <item slot="4" damage="1" amount="16">log</item>
+        <item slot="4" damage="1" amount="64">wood</item>
         <item slot="5" amount="32">ladder</item>
         <item slot="6">water bucket</item>
         <item slot="8" amount="64">cooked chicken</item>
@@ -144,7 +144,6 @@
     <item>leather boots</item>
     <item>arrow</item>
     <item>wood</item>
-    <item>log</item>
     <item>cooked chicken</item>
     <item>ladder</item>
     <item>gold block</item>

--- a/dtcm/standard/airship_battle/map.xml
+++ b/dtcm/standard/airship_battle/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.0.0">
 <name>Airship Battle</name>
-<version>1.2.5</version>
+<version>1.2.6</version>
 <objective>Leak lava from the enemy's obsidian core into the void.</objective>
 <authors>
     <author uuid="30e27366-0b14-4076-8f55-0819ece49ce3"/> <!-- Dewtroid -->
@@ -50,7 +50,7 @@
         <item slot="28" amount="64">arrow</item>
         <item slot="2">diamond pickaxe</item>
         <item slot="3">diamond axe</item>
-        <item slot="4" damage="1" amount="16">log</item>
+        <item slot="4" damage="1" amount="64">wood</item>
         <item slot="5" amount="64">ladder</item>
         <item slot="6">water bucket</item>
         <item slot="8" amount="64">cooked fish</item>
@@ -110,7 +110,7 @@
 </crafting>
 <killreward>
     <item amount="16">arrow</item>
-    <item damage="1" amount="8">log</item>
+    <item damage="1" amount="32">wood</item>
 	<item>golden apple</item>
 </killreward>
 <toolrepair>
@@ -127,7 +127,6 @@
     <item>obsidian</item>
     <item>arrow</item>
     <item>wood</item>
-    <item>log</item>
     <item>cooked fish</item>
     <item>ladder</item>
     <item>gold block</item>

--- a/dtcm/standard/donut_wars/map.xml
+++ b/dtcm/standard/donut_wars/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.3.2">
 <name>Donut Wars</name>
-<version>1.3.9</version>
+<version>1.3.10</version>
 <objective>Leak the enemy team's core and destroy their two monuments!</objective>
 <rules>
     <rule>Dispensers are disabled</rule>
@@ -37,7 +37,7 @@
         <item slot="28" amount="64">arrow</item>
         <item slot="2">diamond pickaxe</item>
         <item slot="3">diamond axe</item>
-        <item slot="4" amount="16">log</item>
+        <item slot="4" amount="64">wood</item>
         <item slot="5" amount="64">ladder</item>
         <item slot="6">water bucket</item>
         <item slot="8" amount="64">golden carrot</item>
@@ -198,7 +198,6 @@
     <item>sign</item>
     <item>ender stone</item>
     <item>wood</item>
-    <item>log</item>
     <item>cooked fish</item>
     <item>golden carrot</item>
     <item>ladder</item>

--- a/dtcm/standard/fort_wars/map.xml
+++ b/dtcm/standard/fort_wars/map.xml
@@ -2,7 +2,7 @@
 <map proto="1.3.0">
 <include src="tutorial.xml"/>
 <name>Fort Wars</name>
-<version>1.4.4</version>
+<version>1.4.5</version>
 <objective>Destroy the enemy's flag!</objective>
 <rules>
     <rule>Players have resistance and reduced knockback in spawn!</rule>
@@ -29,7 +29,8 @@
         <item slot="28" amount="64">arrow</item>
         <item slot="2">diamond pickaxe</item>
         <item slot="3">diamond axe</item>
-        <item slot="4" amount="16">log</item>
+        <item slot="30">diamond spade</item>
+        <item slot="4" amount="64">wood</item>
         <item slot="5" amount="64">ladder</item>
         <item slot="6">water bucket</item>
         <item slot="8" amount="64">apple</item>
@@ -58,6 +59,7 @@
     <tool>bow</tool>
     <tool>diamond pickaxe</tool>
     <tool>diamond axe</tool>
+    <tool>diamond spade</tool>
 </toolrepair>
 <itemremove>
     <item>leather helmet</item>
@@ -67,7 +69,6 @@
     <item>obsidian</item>
     <item>arrow</item>
     <item>wood</item>
-    <item>log</item>
     <item>apple</item>
     <item>coal</item>
     <item>ladder</item>

--- a/dtcm/standard/fortress_battles/map.xml
+++ b/dtcm/standard/fortress_battles/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.3.3">
 <name>Fortress Battles</name>
-<version>3.2.7</version>
+<version>3.2.8</version>
 <objective>Leak lava from the enemy's obsidian core into the void.</objective>
 <rules>
     <rule>You cannot place dispensers on the map!</rule>
@@ -27,7 +27,8 @@
         <item slot="28" amount="64">arrow</item>
         <item slot="2">diamond pickaxe</item>
         <item slot="3">diamond axe</item>
-        <item slot="4" amount="16">log</item>
+        <item slot="30">diamond spade</item>
+        <item slot="4" amount="64">wood</item>
         <item slot="6">water bucket</item>
         <item slot="8" amount="64">cooked fish</item>
         <chestplate enchantment="protection explosions:4">chainmail chestplate</chestplate>
@@ -129,6 +130,7 @@
     <tool>bow</tool>
     <tool>diamond pickaxe</tool>
     <tool>diamond axe</tool>
+    <tool>diamond spade</tool>
 </toolrepair>
 <itemremove>
     <item>leather helmet</item>
@@ -138,7 +140,6 @@
     <item>obsidian</item>
     <item>arrow</item>
     <item>wood</item>
-    <item>log</item>
     <item>cooked fish</item>
     <item>bucket</item>
     <item>water bucket</item>

--- a/dtcm/standard/hot_dam/map.xml
+++ b/dtcm/standard/hot_dam/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.0">
 <name>Hot Dam</name>
-<version>1.3.3</version>
+<version>1.3.4</version>
 <objective>Leak lava from the enemy's obsidian core onto the dam.</objective>
 <authors>
     <author uuid="00c06fa6-1c53-4634-931a-929efd8a52df"/> <!-- Nadastorm -->
@@ -20,6 +20,7 @@
         <item slot="1" unbreakable="true" material="bow"/>
         <item slot="2" unbreakable="true" material="diamond pickaxe"/>
         <item slot="3" unbreakable="true" enchantment="dig speed:2" material="iron axe"/>
+        <item slot="30" unbreakable="true" material="iron spade"/>
         <item slot="4" amount="64" damage="2" material="wood"/>
         <item slot="31" amount="64" damage="2" material="wood"/>
         <item slot="5" amount="64" material="glass"/>
@@ -99,6 +100,7 @@
     <tool>bow</tool>
     <tool>diamond pickaxe</tool>
     <tool>iron axe</tool>
+    <tool>iron spade</tool>
 </toolrepair>
 <itemremove>
     <item>glass</item>

--- a/dtcm/standard/hot_dam_mini/map.xml
+++ b/dtcm/standard/hot_dam_mini/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2">
 <name>Hot Dam Mini</name>
-<version>1.1.3</version>
+<version>1.1.4</version>
 <objective>Leak lava from the enemy's obsidian core onto the dam.</objective>
 <authors>
     <author uuid="00c06fa6-1c53-4634-931a-929efd8a52df"/> <!-- Nadastorm -->
@@ -20,6 +20,7 @@
         <item slot="28" amount="64">arrow</item>
         <item slot="2" unbreakable="true">diamond pickaxe</item>
         <item slot="3" unbreakable="true">iron axe</item>
+        <item slot="30" unbreakable="true">iron spade</item>
         <item slot="4" amount="48" damage="2">wood</item>
         <item slot="5" amount="24">glass</item>
         <item slot="6" amount="16">ladder</item>
@@ -97,6 +98,7 @@
     <tool>iron sword</tool>
     <tool>diamond pickaxe</tool>
     <tool>iron axe</tool>
+    <tool>iron spade</tool>
     <tool>bow</tool>
 </toolrepair>
 <itemremove>

--- a/dtcm/standard/hyperspace/map.xml
+++ b/dtcm/standard/hyperspace/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.3.2">
 <name>Hyperspace</name>
-<version>1.4.3</version>
+<version>1.4.4</version>
 <objective>Destroy the other team's monument</objective>
 <rules>
     <rule>Chests can not be placed or destroyed!</rule>
@@ -24,7 +24,7 @@
         <item slot="28" amount="64">arrow</item>
         <item slot="2">diamond pickaxe</item>
         <item slot="3">iron axe</item>
-        <item slot="4" amount="16">log</item>
+        <item slot="4" amount="64">wood</item>
         <item slot="5" amount="64">stone</item>
         <item slot="6">water bucket</item>
         <item slot="7" amount="32">ladder</item>
@@ -124,7 +124,6 @@
     <item>gold block</item>
     <item>step</item>
     <item>glowstone dust</item>
-    <item>log</item>
     <item>wood</item>
     <item>stone</item>
     <item>baked potato</item>

--- a/dtcm/standard/medieval_warfare/map.xml
+++ b/dtcm/standard/medieval_warfare/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.3.0">
 <name>Medieval Warfare</name>
-<version>1.8.6</version>
+<version>1.8.7</version>
 <objective>Leak lava from the enemy's obsidian core.</objective>
 <authors>
     <author uuid="c1ea235d-4224-46e4-ba4a-638838f6d039"/> <!-- Daffy_Duck01 -->
@@ -22,7 +22,7 @@
         <item slot="2">diamond pickaxe</item>
         <item slot="3">diamond axe</item>
         <item slot="30">diamond spade</item>
-        <item slot="4" amount="16">log</item>
+        <item slot="4" amount="64">wood</item>
         <item slot="5" amount="64">ladder</item>
         <item slot="6">water bucket</item>
         <item slot="8" amount="64">bread</item>
@@ -164,7 +164,6 @@
     <item>obsidian</item>
     <item>arrow</item>
     <item>wood</item>
-    <item>log</item>
     <item>bread</item>
     <item>ladder</item>
     <item>bucket</item>

--- a/dtcm/standard/runes_of_ruin/map.xml
+++ b/dtcm/standard/runes_of_ruin/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.0">
 <name>Runes of Ruin</name>
-<version>1.2.9</version>
+<version>1.2.10</version>
 <objective>Leak lava from the enemy's obsidian core</objective>
 <authors>
     <author uuid="00c06fa6-1c53-4634-931a-929efd8a52df"/> <!-- Nadastorm -->
@@ -23,11 +23,12 @@
         <item slot="28" amount="64" material="arrow"/>
         <item slot="2" material="diamond pickaxe"/>
         <item slot="3" material="diamond axe"/>
+        <item slot="30" material="diamond spade"/>
         <item slot="4" amount="64" material="wood"/>
         <item slot="31" amount="64" material="wood"/>
         <item slot="5" amount="64" material="glass"/>
-        <item slot="32" material="water bucket"/>
-        <item slot="6" amount="64" material="ladder"/>
+        <item slot="32" amount="64" material="ladder"/>
+        <item slot="6" material="water bucket"/>
         <item slot="7" material="golden apple"/>
         <item slot="8" amount="64" material="cooked beef"/>
         <chestplate unbreakable="true" material="chainmail chestplate">
@@ -107,6 +108,7 @@
     <tool>bow</tool>
     <tool>diamond pickaxe</tool>
     <tool>diamond axe</tool>
+    <tool>diamond spade</tool>
 </toolrepair>
 <itemremove>
     <item>cooked beef</item>

--- a/dtcm/standard/sky_traffic/map.xml
+++ b/dtcm/standard/sky_traffic/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.0.0">
 <name>Sky Traffic</name>
-<version>1.7.5</version>
+<version>1.7.6</version>
 <objective>Leak lava from the enemy's obsidian core below their ship.</objective>
 <rules>
     <rule>Players have resistance and reduced knockback in spawn!</rule>
@@ -150,7 +150,7 @@
         <item slot="28" amount="64">arrow</item>
         <item slot="2">diamond pickaxe</item>
         <item slot="3">diamond axe</item>
-        <item slot="4" damage="1" amount="16">log</item>
+        <item slot="4" damage="1" amount="64">wood</item>
         <item slot="5" amount="64">ladder</item>
         <item slot="6">water bucket</item>
         <item slot="8" amount="64">cooked fish</item>
@@ -191,7 +191,6 @@
     <item>obsidian</item>
     <item>arrow</item>
     <item>wood</item>
-    <item>log</item>
     <item>cooked fish</item>
     <item>ladder</item>
     <item>bucket</item>

--- a/dtcm/standard/sky_traffic_2/map.xml
+++ b/dtcm/standard/sky_traffic_2/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.0.0">
 <name>Sky Traffic 2</name>
-<version>1.3.5</version>
+<version>1.3.6</version>
 <objective>Leak lava from the enemy's obsidian core in their yellow submarine.</objective>
 <rules>
     <rule>Players have resistance and reduced knockback in spawn!</rule>
@@ -26,7 +26,7 @@
         <item slot="28" amount="64">arrow</item>
         <item slot="2">diamond pickaxe</item>
         <item slot="3">diamond axe</item>
-        <item slot="4" amount="16">log</item>
+        <item slot="4" amount="64">wood</item>
         <item slot="6">water bucket</item>
         <item slot="8" amount="64">cooked fish</item>
         <potion duration="15s" amplifier="2">regeneration</potion>
@@ -159,7 +159,6 @@
     <item>obsidian</item>
     <item>arrow</item>
     <item>wood</item>
-    <item>log</item>
     <item>cooked fish</item>
     <item>bucket</item>
     <item>water bucket</item>

--- a/dtcm/standard/sunrise_over_paradise/map.xml
+++ b/dtcm/standard/sunrise_over_paradise/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.4.2">
 <name>Sunrise Over Paradise</name>
-<version>1.3.1</version>
+<version>1.3.2</version>
 <genre>Objectives</genre>
 <objective>Break the obsidian from both of the enemy team's monuments.</objective>
 <authors>
@@ -75,6 +75,7 @@
         <item slot="28">arrow</item>
         <item slot="2" unbreakable="true" material="diamond pickaxe"/>
         <item slot="3" unbreakable="true" material="iron axe" enchantment="dig speed:1"/>
+        <item slot="30" unbreakable="true" material="iron spade"/>
         <item slot="4" amount="64" material="wood"/>
         <item slot="5" amount="32" material="glass"/>
         <item slot="8" amount="32" material="cooked fish"/>
@@ -98,6 +99,7 @@
     <tool>stone sword</tool>
     <tool>diamond pickaxe</tool>
     <tool>iron axe</tool>
+    <tool>iron spade</tool>
     <tool>bow</tool>
 </toolrepair>
 <itemremove>

--- a/dtcm/standard/the_fenland/map.xml
+++ b/dtcm/standard/the_fenland/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.3.2">
 <name>The Fenland</name>
-<version>1.2.9</version>
+<version>1.2.10</version>
 <objective>Break the obsidian from the enemy team's monument.</objective>
 <authors>
     <author uuid="e5953ddf-c1fc-4405-9ac9-6939631cd185"/> <!-- McSpider -->
@@ -78,6 +78,7 @@
         <item slot="0" enchantment="durability:1">diamond axe</item>
         <item slot="1" enchantment="arrow infinite:1">bow</item>
         <item slot="2">diamond pickaxe</item>
+        <item slot="3">iron spade</item>
         <item slot="4" amount="64">log</item>
         <item slot="5" amount="32">glass</item>
         <item slot="7" amount="4">gold nugget</item>
@@ -90,6 +91,7 @@
 <toolrepair>
     <tool>diamond axe</tool>
     <tool>diamond pickaxe</tool>
+    <tool>iron spade</tool>
     <tool>bow</tool>
 </toolrepair>
 <itemremove>

--- a/dtcm/standard/tree_of_life/map.xml
+++ b/dtcm/standard/tree_of_life/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.0.0">
 <name>Tree of Life</name>
-<version>3.0.4</version>
+<version>3.0.5</version>
 <objective>Leak lava from the enemy's obsidian core into the void.</objective>
 <authors>
     <author uuid="2a289d2a-d970-49c5-9a6c-01fc0264e317"/> <!-- Stealth5061 -->
@@ -30,6 +30,7 @@
         <item slot="1" material="bow"/>
         <item slot="2" material="diamond pickaxe"/>
         <item slot="3" material="diamond axe"/>
+        <item slot="30" material="diamond spade"/>
         <item slot="4" material="bread" amount="64"/>
         <item slot="5" material="log" amount="64"/>
         <item slot="6" material="ladder" amount="64"/>
@@ -53,6 +54,7 @@
     <tool>bow</tool>
     <tool>diamond pickaxe</tool>
     <tool>diamond axe</tool>
+    <tool>diamond spade</tool>
 </toolrepair>
 <itemremove>
     <item>log</item>

--- a/dtcm/standard/warlock/map.xml
+++ b/dtcm/standard/warlock/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.3.2">
 <name>Warlock</name>
-<version>1.3.9</version>
+<version>1.3.10</version>
 <objective>Break the obsidian from the enemy team's monument.</objective>
 <authors>
     <author uuid="e5953ddf-c1fc-4405-9ac9-6939631cd185"/> <!-- McSpider -->
@@ -23,6 +23,7 @@
         <item slot="28">arrow</item>
         <item slot="2" unbreakable="true">diamond pickaxe</item>
         <item slot="3" unbreakable="true">iron axe</item>
+        <item slot="30" unbreakable="true">iron spade</item>
         <item slot="5" amount="64">glass</item>
         <item slot="6" amount="64" damage="2">wood</item>
         <item slot="17" amount="2">gold nugget</item>
@@ -80,6 +81,7 @@
     <tool>iron sword</tool>
     <tool>diamond pickaxe</tool>
     <tool>iron axe</tool>
+    <tool>iron spade</tool>
     <tool>bow</tool>
 </toolrepair>
 <itemremove>


### PR DESCRIPTION
- Adds shovels to the inventory to be less annoying if players need to
  break soil.
- Gives 64 planks instead of 16 logs to avoid having to uncraft every
  time players respawn.