### PR TITLE
Hekla & Promenade: Correct gamemode tags

### DIFF
--- a/flag/standard/hekla/map.xml
+++ b/flag/standard/hekla/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.4.0">
 <name>Hekla</name>
-<version>1.0.1</version>
+<version>1.0.2</version>
 <objective>Hold the flag for 120 seconds to win!</objective>
 <authors>
 	<author uuid="bbfac3db-dd46-4996-b936-0e2432f33285"/> <!-- Valky -->

--- a/flag/standard/hekla/map.xml
+++ b/flag/standard/hekla/map.xml
@@ -12,7 +12,7 @@
         {"translate":"death.respawn.confirmed.waiting.flagDropped"}
     </message>
 </respawn>
-<gamemode>ctf</gamemode>
+<gamemode>kotf</gamemode>
 <teams>
     <team id="blue" color="blue" max="6">Blue</team>
     <team id="red" color="dark red" max="6">Red</team>

--- a/flag/standard/promenade/map.xml
+++ b/flag/standard/promenade/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.4.0">
 <name>Promenade</name>
-<version>1.1.2</version>
+<version>1.1.3</version>
 <objective>Hold the flag for 120 seconds to win!</objective>
 <authors>
 	<author uuid="bbfac3db-dd46-4996-b936-0e2432f33285"/> <!-- Valky -->

--- a/flag/standard/promenade/map.xml
+++ b/flag/standard/promenade/map.xml
@@ -11,7 +11,7 @@
         {"translate":"death.respawn.confirmed.waiting.flagDropped"}
     </message>
 </respawn>
-<gamemode>ctf</gamemode>
+<gamemode>kotf</gamemode>
 <teams>
     <team id="blue" color="blue" max="5">Blue</team>
     <team id="red" color="dark red" max="5">Red</team>


### PR DESCRIPTION
These maps have the KotF gamemode, but had the CTF tag, causing the wrong title to appear on scoreboard.