### PR TITLE
2014 Rage FFA: Add creation date

### DIFF
--- a/ffa/2014_rage_ffa/map.xml
+++ b/ffa/2014_rage_ffa/map.xml
@@ -1,7 +1,10 @@
 <map proto="1.4.2">
 <name>2014: Rage FFA</name>
 <variant id="halloween" world="halloween" override="true">The Lobby: Halloween</variant>
-<version>1.3.0</version>
+<if variant="default">
+    <created>2018-07-06</created>
+</if>
+<version>1.3.1</version>
 <objective>Get the most kills after 5 minutes!</objective>
 <authors>
     <author uuid="19388047-f04b-43ac-9546-22aa69aea75c" contribution="Lobby Builder"/> <!-- Bleanny -->


### PR DESCRIPTION
I have literally no idea when the Halloween version was made, without access to commit history I won't be able to figure it out.