### PR TITLE
Harvest - change pink colour

### DIFF
--- a/koth/harvest/map.xml
+++ b/koth/harvest/map.xml
@@ -1,7 +1,7 @@
 <map proto="1.4.2">
 <name>Harvest</name>
 <variant id="halloween" world="halloween" override="true">Harvested</variant>
-<version>1.2.0</version>
+<version>1.2.1</version>
 <objective>Be the first team to reach 500 points!</objective>
 <gamemode>koth</gamemode>
 <if variant="default">
@@ -28,7 +28,7 @@
 <teams>
     <team id="blue" color="blue" max="12">Blue</team>
     <team id="orange" color="gold" max="12">Orange</team>
-    <team id="pink" color="red" max="12">Pink</team>
+    <team id="pink" color="light purple" max="12">Pink</team>
     <team id="yellow" color="yellow" max="12">Yellow</team>
 </teams>
 <kits>


### PR DESCRIPTION
In this latest change armour does not follow colour codes. This pull request is to change it so that the pink team is still wearing pink armour, not red.