### PR TITLE
Ice Miners: disable minimum players

### DIFF
--- a/fun/arcade/ice_miners/map.xml
+++ b/fun/arcade/ice_miners/map.xml
@@ -2,14 +2,14 @@
 <name>Ice Miners</name>
 <objective>Collect all the gold you can as you make your way down the tunnel!</objective>
 <gamemode>arcade</gamemode>
-<version>1.2.1</version>
+<version>1.2.2</version>
 <authors>
     <author uuid="e79fbdc9-627e-4dac-97a6-81a3046220d7" /> <!-- AtlasGames -->
 </authors>
 <broadcasts>
     <tip after="1m" every="30s">The scorebox is at the bottom of the map!</tip>
 </broadcasts>
-<players max="8" min="4" max-overfill="8" show-name-tags="false"/>
+<players max="8" max-overfill="8" show-name-tags="false"/>
 <timelock>on</timelock>
 <time>3m</time>
 <spawns>


### PR DESCRIPTION
In the quiet part of the day this map gets picked regularly, but it will not start since not everyone will join and there are not enough players.

![2024-09-13_11 50 17](https://github.com/user-attachments/assets/3f178303-544b-4be7-bf98-d49c3edfb2a1)
