### PR TITLE
Japan: fix + cleanup

### DIFF
--- a/ctw/japan/map.xml
+++ b/ctw/japan/map.xml
@@ -14,7 +14,9 @@
     <kit id="spawn-kit">
         <clear/>
         <item slot="0" unbreakable="true" material="stone sword"/>
-        <item slot="1" unbreakable="true" material="bow" enchantment="infinity"/>
+        <item slot="1" unbreakable="true" material="bow">
+            <enchantment>infinity</enchantment>
+        </item>
         <item slot="28" material="arrow"/>
         <item slot="2" unbreakable="true" material="diamond pickaxe"/>
         <item slot="29" unbreakable="true" material="shears"/>
@@ -32,19 +34,19 @@
 </kits>
 <spawns>
     <default>
-        <regions>
+        <region>
             <point>18.5,22.5,-49.5</point>
-        </regions>
+        </region>
     </default>
-    <spawn team="green" kit="spawn-kit" yaw="-90">
-        <regions>
+    <spawn team="green" kit="spawn-kit">
+        <region yaw="-90">
             <point>62.5,11,21.5</point>
-        </regions>
+        </region>
     </spawn>
-    <spawn team="orange" kit="spawn-kit" yaw="90">
-        <regions>
+    <spawn team="orange" kit="spawn-kit">
+        <region yaw="90">
             <point>-25.5,11,-46.5</point>
-        </regions>
+        </region>
     </spawn>
 </spawns>
 <filters>
@@ -64,15 +66,15 @@
         <everywhere/>
         <rectangle min="-6,-21" max="31,-4"/> <!-- Mid Region -->
     </complement>
+    <apply use="deny(only-beacon)"/>
     <apply enter="orange" region="orange-spawn" message="You may not enter the enemy's spawn!"/>
     <apply enter="green" region="green-spawn" message="You may not enter the enemy's spawn!"/>
     <apply enter="green" use="green" region="red-for-green" message="You may not enter your team's own wool room!"/>
     <apply enter="orange" use="orange" region="cyan-for-orange" message="You may not enter your team's own wool room!"/>
-    <apply block="deny(only-beacon)"/>
-    <apply block="deny(void)" region="void-area" message="You may not place or break blocks here!"/>
     <apply block="deny(any(orange,only-chest))" region="red-for-green" message="You may not modify chests in the wool room, or modify your team's own wool room."/>
     <apply block="deny(any(green,only-chest))" region="cyan-for-orange" message="You may not modify chests in the wool room, or modify your team's own wool room."/>
     <apply block="never" region="spawns" message="You may not modify the spawns!"/>
+    <apply block-place="deny(void)" region="void-area" message="You may not place or break blocks here!"/>
 </regions>
 <wools>
     <wool team="green" color="red" location="-81,12,31">

--- a/ctw/japan/map.xml
+++ b/ctw/japan/map.xml
@@ -1,6 +1,6 @@
-<map proto="1.4.2">
+<map proto="1.5.0">
 <name>Japan</name>
-<version>1.1.2</version>
+<version>1.1.3</version>
 <include id="gapple-kill-reward"/>
 <objective>Bring the enemy's wool back to your own side.</objective>
 <authors>
@@ -14,9 +14,7 @@
     <kit id="spawn-kit">
         <clear/>
         <item slot="0" unbreakable="true" material="stone sword"/>
-        <item slot="1" unbreakable="true" material="bow">
-            <enchantment>infinity</enchantment>
-        </item>
+        <item slot="1" unbreakable="true" material="bow" enchantment="infinity"/>
         <item slot="28" material="arrow"/>
         <item slot="2" unbreakable="true" material="diamond pickaxe"/>
         <item slot="29" unbreakable="true" material="shears"/>
@@ -35,62 +33,46 @@
 <spawns>
     <default>
         <regions>
-            <point yaw="0">18.5,22.02,-49.5</point>
+            <point>18.5,22.5,-49.5</point>
         </regions>
     </default>
-    <spawn team="green" kit="spawn-kit">
+    <spawn team="green" kit="spawn-kit" yaw="-90">
         <regions>
-            <point yaw="-90">62.5,11,21.5</point>
+            <point>62.5,11,21.5</point>
         </regions>
     </spawn>
-    <spawn team="orange" kit="spawn-kit">
+    <spawn team="orange" kit="spawn-kit" yaw="90">
         <regions>
-            <point yaw="90">-25.5,11,-46.5</point>
+            <point>-25.5,11,-46.5</point>
         </regions>
     </spawn>
 </spawns>
 <filters>
-    <deny id="green-in-wr">
-        <any>
-            <team id="only-orange">orange</team>
-            <material>chest</material>
-        </any>
-    </deny>
-    <deny id="orange-in-wr">
-        <any>
-            <team id="only-green">green</team>
-            <material>chest</material>
-        </any>
-    </deny>
-    <deny id="deny-void">
-        <void/>
-    </deny>
-    <deny id="deny-beacon">
-        <material>beacon</material>
-    </deny>
+    <material id="only-chest">chest</material>
+    <material id="only-beacon">beacon</material>
 </filters>
 <regions>
     <union id="spawns">
         <rectangle id="green-spawn" min="54,9" max="75,29"/>
-        <rectangle id="orange-spawn" min="-17,-34" max="-38,-54"/>
+        <rectangle id="orange-spawn" min="-38,-54" max="-17,-34"/>
     </union>
     <union id="wool-rooms">
         <cuboid id="cyan-for-orange" min="105,0,-65" max="123,64,-49"/>
-        <cuboid id="red-for-green" min="-68,0,40" max="-86,64,24"/>
+        <cuboid id="red-for-green" min="-86,0,24" max="-68,64,40"/>
     </union>
-    <complement id="void">
+    <complement id="void-area">
         <everywhere/>
-        <rectangle id="mid" min="31,-21" max="6,-4"/>
+        <rectangle min="-6,-21" max="31,-4"/> <!-- Mid Region -->
     </complement>
-    <apply use="deny-beacon"/>
-    <apply enter="only-orange" region="orange-spawn" message="You may not enter the enemy's spawn!"/>
-    <apply enter="only-green" region="green-spawn" message="You may not enter the enemy's spawn!"/>
-    <apply enter="only-green" use="only-green" region="red-for-green" message="You may not enter your team's own wool room!"/>
-    <apply enter="only-orange" use="only-orange" region="cyan-for-orange" message="You may not enter your team's own wool room!"/>
-    <apply block="green-in-wr" region="red-for-green" message="You may not modify chests in the wool room, or modify your team's own wool room."/>
-    <apply block="orange-in-wr" region="cyan-for-orange" message="You may not modify chests in the wool room, or modify your team's own wool room."/>
+    <apply enter="orange" region="orange-spawn" message="You may not enter the enemy's spawn!"/>
+    <apply enter="green" region="green-spawn" message="You may not enter the enemy's spawn!"/>
+    <apply enter="green" use="green" region="red-for-green" message="You may not enter your team's own wool room!"/>
+    <apply enter="orange" use="orange" region="cyan-for-orange" message="You may not enter your team's own wool room!"/>
+    <apply block="deny(only-beacon)"/>
+    <apply block="deny(void)" region="void-area" message="You may not place or break blocks here!"/>
+    <apply block="deny(any(orange,only-chest))" region="red-for-green" message="You may not modify chests in the wool room, or modify your team's own wool room."/>
+    <apply block="deny(any(green,only-chest))" region="cyan-for-orange" message="You may not modify chests in the wool room, or modify your team's own wool room."/>
     <apply block="never" region="spawns" message="You may not modify the spawns!"/>
-    <apply block="deny-void" region="void" message="You may not place or break blocks here!"/>
 </regions>
 <wools>
     <wool team="green" color="red" location="-81,12,31">


### PR DESCRIPTION
**This update does not modify gameplay**
- updated to protocol 1.5.0
- fixed bug where players could not destroy blocks that were over void (leaves and logs)
- moved enchantments to inline
- removed yaw definition in default region, because default value is 0
- updated yaw values to be in spawn element
- sorted min and max values for readability
- replaced filters with inline filters
Credit to @PeakDominance for assistance with the XML!