### PR TITLE
Restore core modes to DTC maps converted from proto <1.3.2

### DIFF
--- a/dtcm/black_gold/map.xml
+++ b/dtcm/black_gold/map.xml
@@ -1,6 +1,6 @@
-<map proto="1.4.2">
+<map proto="1.5.0">
 <name>Black Gold</name>
-<version>1.0.8</version>
+<version>1.0.9</version>
 <created>2012-10-20</created>
 <objective>Leak lava from the enemy core!</objective>
 <authors>
@@ -23,7 +23,7 @@
         <item slot="0" material="iron sword"/>
         <item slot="1" material="bow"/>
         <item slot="2" material="diamond pickaxe"/>
-        <item slot="3" amount="1" enchantment="efficiency:2;unbreaking:2" material="iron axe"/>
+        <item slot="3" enchantment="efficiency:2;unbreaking:2" material="iron axe"/>
         <item slot="4" amount="16" damage="1" material="log"/>
         <item slot="5" amount="64" material="glass"/>
         <item slot="6" amount="32" material="grilled pork"/>
@@ -34,27 +34,24 @@
 </kits>
 <spawns>
     <spawn team="blue" kit="spawn-kit" yaw="90">
-        <regions>
+        <region>
             <point>-199,11,274</point>
-        </regions>
+        </region>
     </spawn>
     <spawn team="red" kit="spawn-kit" yaw="-90">
-        <regions>
+        <region>
             <point>-466,11,274</point>
-        </regions>
+        </region>
     </spawn>
     <default>
-        <regions>
+        <region>
             <point>-188,49,207</point>
-        </regions>
+        </region>
     </default>
 </spawns>
 <filters>
     <team id="only-red">red</team>
     <team id="only-blue">blue</team>
-    <deny id="deny-void">
-        <void/>
-    </deny>
 </filters>
 <regions>
     <union id="spawn-rooms">
@@ -76,9 +73,9 @@
     <apply region="blue-spawn-room" enter="only-blue" message="You may not enter Blue's spawn!"/>
     <apply region="red-spawn-room" enter="only-red" message="You may not enter Red's spawn!"/>
     <apply region="spawn-roof" block="never" message="You may not modify the spawn room/roof!"/>
-    <apply region="outside-playable" block="deny-void" message="You may not build outside of the map."/>
+    <apply region="outside-playable" block="deny(void)" message="You may not build outside of the map."/>
 </regions>
-<cores leak="6">
+<cores leak="6" mode-changes="true">
     <core team="blue">
         <region>
             <cuboid min="-210,42,271" max="-203,49,278"/>
@@ -90,6 +87,10 @@
         </region>
     </core>
 </cores>
+<modes>
+    <mode after="15m" material="gold block"/>
+    <mode after="20m" material="glass"/>
+</modes>
 <toolrepair>
     <tool>iron sword</tool>
     <tool>bow</tool>

--- a/dtcm/blocks_dtc/map.xml
+++ b/dtcm/blocks_dtc/map.xml
@@ -1,10 +1,10 @@
-<map proto="1.4.2">
+<map proto="1.5.0">
 <name>Blocks DTC</name>
 <variant id="christmas" world="christmas" override="true">Holiday Blocks</variant>
 <variant id="halloween" world="halloween" override="true">Haunted Blocks</variant>
 <variant id="tnt" world="dtc_tnt">TNT</variant>
 <variant id="te" world="dtc_te">TE</variant>
-<version>1.5.0</version>
+<version>1.5.1</version>
 <objective>Leak lava from the enemy's obsidian core.</objective>
 <if variant="default">
     <created>2012-06-29</created>
@@ -17,6 +17,9 @@
 </if>
 <if variant="tnt,te">
     <created>2013-12-13</created>
+</if>
+<if variant="tnt">
+    <include id="gapple-kill-reward"/>
 </if>
 <authors>
     <author uuid="060baa18-2852-40d8-afcb-e61607c04be3"/> <!-- pepsidawg00 -->
@@ -43,21 +46,21 @@
         <clear/>
         <!-- TE variant intentionally has no kits -->
         <unless variant="te">
-            <item slot="0">diamond sword</item>
-            <item slot="1">bow</item>
-            <item slot="2" enchantment="efficiency:2;unbreaking:3">iron pickaxe</item>
-            <item slot="3" enchantment="efficiency">diamond axe</item>
-            <item slot="4" amount="64" damage="2">log</item>
-            <item slot="5" amount="64" team-color="true">wool</item>
-            <item slot="6" amount="64">melon block</item>
-            <item slot="7" enchantment="efficiency">shears</item>
-            <item slot="8" amount="64">golden apple</item>
-            <item slot="28" amount="64">arrow</item>
-            <item slot="30">diamond spade</item>
+            <item slot="0" material="diamond sword"/>
+            <item slot="1" material="bow"/>
+            <item slot="2" enchantment="efficiency:2;unbreaking:3" material="iron pickaxe"/>
+            <item slot="3" enchantment="efficiency" material="diamond axe"/>
+            <item slot="4" amount="64" damage="2" material="log"/>
+            <item slot="5" amount="64" team-color="true" material="wool"/>
+            <item slot="6" amount="64" material="melon block"/>
+            <item slot="7" enchantment="efficiency" material="shears"/>
+            <item slot="8" amount="64" material="golden apple"/>
+            <item slot="28" amount="64" material="arrow"/>
+            <item slot="30" material="diamond spade"/>
             <if variant="tnt">
-                <chestplate team-color="true" unbreakable="true">leather chestplate</chestplate>
-                <leggings team-color="true" unbreakable="true">leather leggings</leggings>
-                <boots team-color="true" unbreakable="true">leather boots</boots>
+                <chestplate team-color="true" unbreakable="true" material="leather chestplate"/>
+                <leggings team-color="true" unbreakable="true" material="leather leggings"/>
+                <boots team-color="true" unbreakable="true" material="leather boots"/>
             </if>
             <effect amplifier="5" duration="6">damage resistance</effect>
             <effect duration="6">strength</effect>
@@ -149,19 +152,11 @@
     </union>
     <apply region="storages" block-break="only-water" block-place="never" message="You may not modify storage room!"/>
     <apply region="tnt-chests" block="never" message="You may not break the chests!"/>
-    <apply region="red-storage-main" enter="only-red" message="You may not enter the enemy base!"/>
-    <apply region="blue-storage-main" enter="only-blue" message="You may not enter the enemy base!"/>
+    <apply region="red-storage-main" enter="only-red" message="You may not enter the enemy's base!"/>
+    <apply region="blue-storage-main" enter="only-blue" message="You may not enter the enemy's base!"/>
     <apply region="playable-inverse" block="never" message="You may not build in the void on the side"/>
 </regions>
-<!-- Only TNT variant has core modes -->
-<constant id="cores-mode-changes" delete="true"/>
-<if variant="tnt">
-    <constant id="cores-mode-changes">true</constant>
-    <modes>
-        <mode after="20m" material="gold block"/>
-    </modes>
-</if>
-<cores material="obsidian" leak="8" mode-changes="${cores-mode-changes}">
+<cores material="obsidian" leak="8" mode-changes="true">
     <core team="blue">
         <region>
             <if variant="default,tnt,te">
@@ -189,6 +184,17 @@
         </region>
     </core>
 </cores>
+<if variant="tnt">
+    <modes>
+        <if variant="tnt">
+            <mode after="20m" material="gold block"/>
+        </if>
+        <unless variant="tnt">
+            <mode after="15m" material="gold block"/>
+            <mode after="20m" material="glass"/>
+        </unless>
+    </modes>
+</if>
 <maxbuildheight>60</maxbuildheight>
 <gamerules>
     <doFireTick>false</doFireTick>
@@ -197,9 +203,6 @@
     <kill-rewards>
         <kill-reward>
             <item amount="16" material="arrow"/>
-            <if variant="tnt">
-                <item material="golden apple"/>
-            </if>
         </kill-reward>
     </kill-rewards>
     <if variant="tnt">
@@ -245,51 +248,4 @@
         <velocityMod>2.0</velocityMod>
     </modifybowprojectile>
 </if>
-<!-- include src="tutorial.xml"/ -->
-<!-- <tutorial>
-    <stage title="Destroy the Core">
-        <message>
-            <line>`rThis map is a `a`lDestroy the Core `r(DTC) map.</line>
-            <line>`rThe objective is to leak lava from the enemy's `5obsidian `rcore.</line>
-        </message>
-        <teleport>
-            <point yaw="0" pitch="50">16.5,102,18</point>
-        </teleport>
-    </stage>
-    <stage title="Spawn">
-        <message>
-            <line>`rYou spawn inside your base which looks like a double chest.</line>
-            <line>`rThe chests in the base contain all the necessary gear to get ready for battle!</line>
-        </message>
-        <teleport>
-            <point yaw="-90" pitch="15">83,31,72</point>
-        </teleport>
-    </stage>
-    <stage title="Armor">
-        <message>
-            <line>`bDiamond blocks `rcan be found in both of the furnaces on either side of the base.</line>
-            <line>You can use diamond blocks to craft armor.</line>
-        </message>
-        <teleport>
-            <point yaw="0" pitch="25">107,33,42</point>
-        </teleport>
-    </stage>
-    <stage title="The Core">
-        <message>
-            <line>This is `5obsidian `rcore, break your enemy's `5obsidian `rcore and leak the `clava `rfrom inside the core to win.</line>
-        </message>
-        <teleport>
-            <point yaw="-150" pitch="35">83,45,80</point>
-        </teleport>
-    </stage>
-    <stage title="Extra Supplies">
-        <message>
-            <line>`rUseful extra supplies can be found above the base.</line>
-            <line>Stairs from the `aleft `rand `aright `rof spawn allow direct access.</line>
-        </message>
-        <teleport>
-            <point yaw="-50" pitch="-10">90,42,60</point>
-        </teleport>
-    </stage>
-</tutorial> -->
 </map>

--- a/dtcm/hot_dam_mini/map.xml
+++ b/dtcm/hot_dam_mini/map.xml
@@ -1,7 +1,8 @@
-<map proto="1.4.2">
+<map proto="1.5.0">
 <name>Hot Dam Mini</name>
-<version>1.1.8</version>
+<version>1.1.9</version>
 <objective>Leak lava from the enemy's obsidian core onto the dam!</objective>
+<include id="gapple-kill-reward"/>
 <authors>
     <author uuid="00c06fa6-1c53-4634-931a-929efd8a52df"/> <!-- Nadastorm -->
 </authors>
@@ -29,7 +30,7 @@
         <chestplate material="leather chestplate" team-color="true" unbreakable="true"/>
         <leggings material="leather leggings" team-color="true" unbreakable="true"/>
         <boots material="leather boots" team-color="true" unbreakable="true"/>
-        <effect duration="6" amplifier="1">heal</effect>
+        <effect duration="6">heal</effect>
         <effect duration="6" amplifier="2">damage resistance</effect>
     </kit>
 </kits>
@@ -38,16 +39,9 @@
     <spawn team="red-team" kit="spawn-kit" region="red-spawn-point" yaw="180"/>
     <default region="obs-spawn-point" yaw="-45"/>
 </spawns>
-<cores material="obsidian" leak="2">
-    <core team="blue-team" region="blue-core"/>
-    <core team="red-team" region="red-core"/>
-</cores>
 <filters>
     <team id="only-blue">blue-team</team>
     <team id="only-red">red-team</team>
-    <deny id="no-void">
-        <void/>
-    </deny>
 </filters>
 <regions>
     <cylinder id="blue-spawn-point" base="-89,38,127" radius="1" height="0"/>
@@ -69,8 +63,16 @@
     <apply enter="only-blue" use="only-blue" region="blue-building-enter" message="You may not enter the enemy's spawn!"/>
     <apply enter="only-red" use="only-red" region="red-building-enter" message="You may not enter the enemy's spawn!"/>
     <apply block="never" region="spawn-protection" message="You may not edit spawn!"/>
-    <apply block-place="no-void" message="You may not edit the void!"/>
+    <apply block-place="deny(void)" message="You may not edit the void!"/>
 </regions>
+<cores material="obsidian" leak="2" mode-changes="true">
+    <core team="blue-team" region="blue-core"/>
+    <core team="red-team" region="red-core"/>
+</cores>
+<modes>
+    <mode after="15m" material="gold block"/>
+    <mode after="20m" material="glass"/>
+</modes>
 <toolrepair>
     <tool>iron sword</tool>
     <tool>diamond pickaxe</tool>
@@ -111,16 +113,15 @@
         </drops>
     </rule>
 </block-drops>
-<maxbuildheight>51</maxbuildheight>
-<hunger>
-    <depletion>off</depletion>
-</hunger>
 <kill-rewards>
     <kill-reward>
-        <item material="golden apple"/>
         <item material="wood" damage="2" amount="8"/>
         <item material="glass" amount="4"/>
         <item material="arrow" amount="16"/>
     </kill-reward>
 </kill-rewards>
+<maxbuildheight>51</maxbuildheight>
+<hunger>
+    <depletion>off</depletion>
+</hunger>
 </map>

--- a/dtcm/medieval_warfare/map.xml
+++ b/dtcm/medieval_warfare/map.xml
@@ -1,13 +1,14 @@
-<map proto="1.4.2">
+<map proto="1.5.0">
 <name>Medieval Warfare</name>
 <variant id="dte" world="dte">DTE</variant>
-<version>1.8.10</version>
+<version>1.8.11</version>
 <unless variant="dte">
     <objective>Leak lava from the enemy's obsidian core.</objective>
 </unless>
 <if variant="dte">
     <objective>Demolish the enemy's castle</objective>
 </if>
+<created>2012-05-27</created>
 <authors>
     <author uuid="c1ea235d-4224-46e4-ba4a-638838f6d039"/> <!-- Daffy_Duck01 -->
 </authors>
@@ -24,11 +25,11 @@
         <alert after="190s" filter="wall-exists">THE WALL IS GONE!! BOOM BOOM TIEM!!!111</alert> <!-- Original monument mode message -->
     </broadcasts>
 </if>
-<created>2012-05-27</created>
 <rules>
     <rule>Dispensers cannot be placed on this map</rule>
     <rule>Players have resistance and reduced knockback in spawn!</rule>
 </rules>
+<include id="gapple-kill-reward"/>
 <if variant="dte">
     <teams>
         <team id="blue" color="blue" max="24">Blue</team>
@@ -91,28 +92,19 @@
 </kits>
 <filters>
     <!-- Recent changes to implement spawn and chest protection -->
-    <deny id="deny-chest-break">
-        <material>chest</material>
-    </deny>
-    <deny id="only-red">
-        <team>blue</team>
-    </deny>
-    <deny id="only-blue">
-        <team>red</team>
-    </deny>
     <deny id="deny-dispenser">
         <material>dispenser</material>
     </deny>
     <not id="anti-tnt-red">
         <all>
             <material>tnt</material>
-            <team>red</team>
+            <team id="only-red">red</team>
         </all>
     </not>
     <not id="anti-tnt-blue">
         <all>
             <material>tnt</material>
-            <team>blue</team>
+            <team id="only-blue">blue</team>
         </all>
     </not>
     <deny id="deny-chest">
@@ -122,6 +114,7 @@
         <material>glass</material>
     </deny>
     <if variant="dte">
+        <!-- TODO: turn wall into a mode that can be controlled by commands -->
         <any id="destroy-wall">
             <after duration="190s" message="The wall comes down in {0}">
                 <all>
@@ -137,9 +130,7 @@
     <!-- Recent changes to implement spawn and chest protection -->
     <apply lend-kit="spawn-protection" filter="only-blue" region="blue-spawn-protect"/>
     <apply lend-kit="spawn-protection" filter="only-red" region="red-spawn-protect"/>
-    <!-- <apply block="deny-chest-break" message="This block can not be placed or broken on this map!">
-        <region id="map"/>
-    </apply> -->
+    <!-- <apply region="map" block="deny-chest" message="This block can not be placed or broken on this map!"/> -->
     <unless variant="dte">
         <union id="spawn">
             <cuboid id="blue-spawn-protect" min="57,93,74" max="63,oo,80"/>
@@ -237,7 +228,7 @@
     </if>
 </regions>
 <unless variant="dte">
-    <cores material="obsidian" leak="3">
+    <cores material="obsidian" leak="3" mode-changes="true">
         <core team="blue">
             <region><cuboid min="30,97,75" max="34,101,79"/></region>
         </core>
@@ -245,6 +236,10 @@
             <region><cuboid min="-55,97,75" max="-51,101,79"/></region>
         </core>
     </cores>
+    <modes>
+        <mode after="15m" material="gold block"/>
+        <mode after="20m" material="glass"/>
+    </modes>
 </unless>
 <if variant="dte">
     <variables>
@@ -271,7 +266,6 @@
 <kill-rewards>
     <kill-reward>
         <item amount="16" material="arrow"/>
-        <item material="golden apple"/>
     </kill-reward>
 </kill-rewards>
 <crafting>

--- a/dtcm/nightsail/map.xml
+++ b/dtcm/nightsail/map.xml
@@ -1,6 +1,6 @@
-<map proto="1.4.2">
+<map proto="1.5.0">
 <name>Nightsail</name>
-<version>2.3.3</version>
+<version>2.3.4</version>
 <created>2013-08-30</created>
 <objective>Leak lava from the enemy's obsidian core</objective>
 <authors>
@@ -45,9 +45,9 @@
         </regions>
     </spawn>
     <default yaw="-90">
-        <regions>
+        <region>
             <cylinder base="2030.5,55,-1507.5" radius="2" height="0"/>
-        </regions>
+        </region>
     </default>
 </spawns>
 <filters>
@@ -79,7 +79,7 @@
     </apply>
     <apply region="playable-inverse" block="never"/>
 </regions>
-<cores leak="8">
+<cores leak="8" mode-changes="true">
     <core team="red">
         <region>
             <cuboid min="2066,16,-1551" max="2064,13,-1547"/>
@@ -91,6 +91,10 @@
         </region>
     </core>
 </cores>
+<modes>
+    <mode after="15m" material="gold block"/>
+    <mode after="20m" material="glass"/>
+</modes>
 <toolrepair>
     <tool>stone sword</tool>
     <tool>bow</tool>
@@ -112,60 +116,4 @@
 </itemremove>
 <maxbuildheight>20</maxbuildheight>
 <timelock>off</timelock>
-<!-- <tutorial>
-    <stage title="Destroy the Core">
-        <message>
-            <line>`rThis map is a `a`lDestroy the Core (DTC) `rmap.</line>
-            <line>The objective is to leak the lava from other team's core on their side.</line>
-        </message>
-        <teleport>
-            <point yaw="90" pitch="35">2119,43,-1509.5</point>
-        </teleport>
-    </stage>
-    <stage title="Blue Spawn">
-        <message>
-            <line>`rThis is one of the `bBlue Team`r's two spawns.</line>
-            <line>`rYou spawn with gear ready to go into battle!</line>
-        </message>
-        <teleport>
-            <point yaw="-135" pitch="20">2093,17,-1426.5</point>
-        </teleport>
-    </stage>
-    <stage title="Red Spawn">
-        <message>
-            <line>`rThis is one of the `cRed Team`r's two spawns.</line>
-            <line>`rYou spawn with gear ready to go into battle!</line>
-        </message>
-        <teleport>
-            <point yaw="45" pitch="20">2034,17,-1589.5</point>
-        </teleport>
-    </stage>
-    <stage title="Red Core">
-        <message>
-            <line>`rThis is the `cRed Core`r.</line>
-            <line>`rThe `5obsidian blocks`r hold `clava`r inside. `bBlue Team `rneeds to break the obsidian blocks to leak the lava out of the core to win.</line>
-        </message>
-        <teleport>
-            <point yaw="180" pitch="40">2064.5,22,-1539.5</point>
-        </teleport>
-    </stage>
-    <stage title="Blue Core">
-        <message>
-            <line>`rThis is the `bBlue Core`r.</line>
-            <line>`rThe `5obsidian blocks`r hold `clava`r inside. `cRed Team `rneeds to break the obsidian blocks to leak the lava out of the core to win.</line>
-        </message>
-        <teleport>
-            <point yaw="0" pitch="40">2064.5,22,-1476.5</point>
-        </teleport>
-    </stage>
-    <stage title="Diamond Pickaxe Spawners">
-        <message>
-            <line>`rEach side has spawners in the middle that spawn `bDiamond Pickaxes`r.</line>
-            <line>`rYou need a `bDiamond Pickaxe`r to break the `5obsidian core`r. Don't forget to grab one!</line>
-        </message>
-        <teleport>
-            <point yaw="180" pitch="45">2064.5,20,-1427.5</point>
-        </teleport>
-    </stage>
-</tutorial> -->
 </map>

--- a/dtcm/precipice/map.xml
+++ b/dtcm/precipice/map.xml
@@ -1,7 +1,8 @@
-<map proto="1.4.2">
+<map proto="1.5.0">
 <name>Precipice</name>
-<version>1.0.5</version>
+<version>1.0.6</version>
 <objective>Leak lava from the enemy team's core!</objective>
+<include id="gapple-kill-reward"/>
 <authors>
     <author uuid="b0b3c5d5-e9bd-4984-bc07-1bd552d4b042"/> <!-- Beebou -->
 </authors>
@@ -35,19 +36,19 @@
 </kits>
 <spawns>
     <spawn team="red" kit="spawn-kit" yaw="180">
-        <regions>
+        <region>
             <cuboid min="26,81,3" max="19,81,1"/>
-        </regions>
+        </region>
     </spawn>
     <spawn team="blue" kit="spawn-kit">
-        <regions>
+        <region>
             <cuboid min="-87,81,-62" max="-78,81,-65"/>
-        </regions>
+        </region>
     </spawn>
     <default>
-        <regions>
+        <region>
             <cuboid min="-26,108,79" max="-33,108,85"/>
-        </regions>
+        </region>
     </default>
 </spawns>
 <filters>
@@ -67,7 +68,7 @@
     <apply region="spawns" block="never" message="You may not modify the spawns!"/>
     <apply region="map-inverse" block="never" message="You may not build outside the map!"/>
 </regions>
-<cores leak="4">
+<cores leak="4" mode-changes="true">
     <core team="red">
         <region>
             <cuboid min="119,99,-27" max="125,89,-31"/>
@@ -79,6 +80,10 @@
         </region>
     </core>
 </cores>
+<modes>
+    <mode after="15m" material="gold block"/>
+    <mode after="20m" material="glass"/>
+</modes>
 <toolrepair>
     <tool>stone sword</tool>
     <tool>stone axe</tool>
@@ -97,7 +102,6 @@
 <kill-rewards>
     <kill-reward>
         <item amount="16" material="arrow"/>
-        <item material="golden apple"/>
     </kill-reward>
 </kill-rewards>
 <timelock>on</timelock>

--- a/dtcm/solitudemc/map.xml
+++ b/dtcm/solitudemc/map.xml
@@ -1,6 +1,6 @@
-<map proto="1.4.2">
+<map proto="1.5.0">
 <name>SolitudeMC</name>
-<version>1.5.1</version>
+<version>1.5.2</version>
 <variant id="christmas" world="christmas">Christmas</variant>
 <variant id="halloween" world="halloween">Halloween</variant>
 <objective>Leak the lava from your enemy's core!</objective>
@@ -87,15 +87,10 @@
             <material>stained glass:14</material>
         </if>
     </deny>
-    <deny id="no-void">
-        <void/>
-    </deny>
-    <deny id="deny-some">
-        <any>
-            <material>dispenser</material>
-            <material>beacon</material>
-        </any>
-    </deny>
+    <any id="interactive-blocks">
+        <material>dispenser</material>
+        <material>beacon</material>
+    </any>
 </filters>
 <regions>
     <apply block="never" message="You may not build in the spawns!">
@@ -105,8 +100,8 @@
         </region>
     </apply>
     <apply block="deny-stained-glass"/>
-    <apply block="deny-some" use="deny-some" message="You may not interact with Beacons and Dispensers!"/>
-    <apply block="no-void" message="You may not build in the void!">
+    <apply block="deny(interactive-blocks)" use="deny(interactive-blocks)" message="You may not interact with Beacons and Dispensers!"/>
+    <apply block="deny(void)" message="You may not build in the void!">
         <region>
             <negative id="outside-map">
                 <rectangle id="whole-map" min="-29,66" max="31,-66"/>
@@ -114,7 +109,7 @@
         </region>
     </apply>
 </regions>
-<cores leak="6">
+<cores leak="6" mode-changes="true">
     <core team="cyan">
         <region>
             <cuboid id="cyan-core" min="25,28,-47" max="19,34,-53"/>
@@ -126,6 +121,10 @@
         </region>
     </core>
 </cores>
+<modes>
+    <mode after="15m" material="gold block"/>
+    <mode after="20m" material="glass"/>
+</modes>
 <toolrepair>
     <tool>iron sword</tool>
     <tool>bow</tool>

--- a/dtcm/spaceship_battles_ii/map.xml
+++ b/dtcm/spaceship_battles_ii/map.xml
@@ -1,12 +1,13 @@
-<map proto="1.4.2">
+<map proto="1.5.0">
 <name>Spaceship Battles II</name>
-<version>1.2.4</version>
+<version>1.2.5</version>
 <objective>Leak lava from the enemy's obsidian core and destroy the enemy's Comm Tower made of coal ore.</objective>
+<created>2012-07-04</created>
+<include id="gapple-kill-reward"/>
 <authors>
     <author uuid="73711d58-d786-4007-8c95-c93b1311de1a"/> <!-- Oversoul96 -->
     <author uuid="c97373ef-4582-4350-8993-8a78f2775c29"/> <!-- Eclipsen -->
 </authors>
-<created>2012-07-04</created>
 <teams>
     <team id="blue" color="blue" max="40">Blue</team>
     <team id="red" color="dark red" max="40">Red</team>
@@ -36,27 +37,22 @@
     </kit>
 </kits>
 <spawns>
-    <default>
-        <region yaw="270">
+    <default yaw="270">
+        <region>
             <cylinder base="280,68,275" radius="4" height="0"/>
         </region>
     </default>
-    <spawn team="blue" kit="spawn-kit">
-        <region yaw="90">
+    <spawn team="blue" kit="spawn-kit" yaw="90">
+        <region>
             <cuboid min="208.5,97,360.5" max="214.5,97,362.5"/>
         </region>
     </spawn>
-    <spawn team="red" kit="spawn-kit">
-        <region yaw="90">
+    <spawn team="red" kit="spawn-kit" yaw="90">
+        <region>
             <cuboid min="208.5,97,193.5" max="214.5,97,195.5"/>
         </region>
     </spawn>
 </spawns>
-<filters>
-    <not id="deny-void">
-        <void/>
-    </not>
-</filters>
 <regions>
     <negative id="playable-inverse">
         <cuboid id="playable" min="9,-oo,121" max="266,93,429"/>
@@ -71,9 +67,9 @@
     </union>
     <apply block="never" message="You may not cover the spawn pools." region="spawn-pools"/>
     <apply block="never" region="spawn-ships"/>
-    <apply block-break="always" block-place="deny-void" message="You may not build outside of the map!" region="playable-inverse"/>
+    <apply block-break="always" block-place="deny(void)" message="You may not build outside of the map!" region="playable-inverse"/>
 </regions>
-<cores material="obsidian" leak="-1">
+<cores material="obsidian" leak="-1" mode-changes="true">
     <core team="blue">
         <region>
             <cuboid min="118,20,358" max="127,27,365"/>
@@ -97,6 +93,10 @@
         </region>
     </destroyable>
 </destroyables>
+<modes>
+    <mode after="15m" material="gold block"/>
+    <mode after="20m" material="glass"/>
+</modes>
 <maxbuildheight>61</maxbuildheight>
 <crafting>
     <disable>boat</disable>
@@ -163,7 +163,6 @@
     <kill-reward>
         <item amount="32" material="wood"/>
         <item amount="16" material="cobblestone"/>
-        <item material="golden apple"/>
     </kill-reward>
 </kill-rewards>
 </map>

--- a/dtcm/swamped/map.xml
+++ b/dtcm/swamped/map.xml
@@ -1,7 +1,8 @@
-<map proto="1.4.2">
+<map proto="1.5.0">
 <name>Swamped</name>
-<version>1.1.6</version>
+<version>1.1.7</version>
 <objective>Destroy the enemy's core in front of their spawn.</objective>
+<include id="gapple-kill-reward"/>
 <authors>
     <author uuid="e8d1ad63-bd9e-4d0e-9a6c-27f2b047d924" contribution="Overall map design"/> <!-- Mikeg542 -->
     <author uuid="fcbc5806-e7fd-45f1-845a-22f1df93c9bf" contribution="Many details, aesthetics, feedback, etc"/> <!-- Minii_ -->
@@ -25,19 +26,19 @@
 </kits>
 <spawns>
     <default yaw="90">
-        <regions>
+        <region>
             <cylinder base="56,48,11" radius="2" height="0"/>
-        </regions>
+        </region>
     </default>
     <spawn team="orange" kit="spawn-kit">
-        <regions>
+        <region>
             <cylinder base="-1,4,-129" radius="2" height="0"/>
-        </regions>
+        </region>
     </spawn>
     <spawn team="purple" kit="spawn-kit" yaw="180">
-        <regions>
+        <region>
             <cylinder base="-2,4,129" radius="2" height="0"/>
-        </regions>
+        </region>
     </spawn>
 </spawns>
 <regions>
@@ -46,7 +47,7 @@
     </negative>
     <apply region="playable-inverse" block="never" message="You may not build outside the map or in spawns!"/>
 </regions>
-<cores leak="4">
+<cores leak="4" mode-changes="true">
     <core team="orange">
         <region>
             <cuboid min="2,24,-87" max="-4,15,-92"/>
@@ -58,6 +59,10 @@
         </region>
     </core>
 </cores>
+<modes>
+    <mode after="15m" material="gold block"/>
+    <mode after="20m" material="glass"/>
+</modes>
 <toolrepair>
     <tool>iron axe</tool>
     <tool>iron sword</tool>
@@ -73,49 +78,6 @@
     <item>wood</item>
     <item>golden apple</item>
 </itemremove>
-<kill-rewards>
-    <kill-reward>
-        <item material="golden apple"/>
-    </kill-reward>
-</kill-rewards>
 <timelock>on</timelock>
 <maxbuildheight>48</maxbuildheight>
-<!-- <tutorial>
-    <stage title="Destroy the Core">
-        <message>
-            <line>`rThis map is a `a`lDestroy the Core `r(DTC) map.</line>
-            <line>`rThe objective is to leak lava from the enemy's `5obsidian `rcore.</line>
-        </message>
-        <teleport>
-            <point yaw="90" pitch="50">42,48,0</point>
-        </teleport>
-    </stage>
-    <stage title="Spawn">
-        <message>
-            <line>`rYou spawn inside your base with your basic gear provided.</line>
-            <line>`rThe upper floor contains some additional supplies for defenses and bridges</line>
-        </message>
-        <teleport>
-            <point yaw="45" pitch="45">11,18,110</point>
-        </teleport>
-    </stage>
-    <stage title="Armor">
-        <message>
-            <line>`bIron blocks are available throughout the map for buckets and armor</line>
-            <line>The main supply is visible here, straight ahead and down from the spawn.</line>
-        </message>
-        <teleport>
-            <point yaw="135" pitch="0">-1,2,100</point>
-        </teleport>
-    </stage>
-    <stage title="The Core">
-        <message>
-            <line>This is `5obsidian `rcore, break your enemy's `5obsidian `rcore and leak the `clava `rfrom inside the core to win.</line>
-            <line>`rMake sure to defend your own to stop the enemy team from winning!</line>
-        </message>
-        <teleport>
-            <point yaw="0" pitch="0">-1,20,76</point>
-        </teleport>
-    </stage>
-</tutorial> -->
 </map>

--- a/dtcm/synergy/map.xml
+++ b/dtcm/synergy/map.xml
@@ -1,7 +1,8 @@
-<map proto="1.4.2">
+<map proto="1.5.0">
 <name>Synergy</name>
-<version>1.1.8</version>
+<version>1.1.9</version>
 <objective>Leak lava from the core and destroy both team's monuments.</objective>
+<include id="gapple-kill-reward"/>
 <authors>
     <author uuid="df5fd9f4-4840-4293-9346-5c77bf7bc08f"/> <!-- kalikakitty -->
 </authors>
@@ -37,20 +38,20 @@
 <spawns>
     <spawns kit="spawn-kit">
         <spawn team="purple" yaw="-90">
-            <regions>
+            <region>
                 <cuboid min="-97,5,-112" max="-96,5,-111"/>
-            </regions>
+            </region>
         </spawn>
         <spawn team="cyan" yaw="90">
-            <regions>
+            <region>
                 <cuboid min="118,5,-111" max="117,5,-112"/>
-            </regions>
+            </region>
         </spawn>
     </spawns>
     <default>
-        <regions>
+        <region>
             <cuboid min="8,21,-185" max="12,21,-181"/>
-        </regions>
+        </region>
     </default>
 </spawns>
 <filters>
@@ -61,9 +62,6 @@
         <material>trap door</material>
         <material>glass</material>
     </any>
-    <deny id="no-void">
-        <void/>
-    </deny>
     <any id="gravel">
         <material>gravel</material>
         <material>stone plate</material>
@@ -113,7 +111,7 @@
     <apply region="purple-base" enter="only-purple" message="You may not enter the opposing team's spawn!"/>
     <apply region="extra-loot-chests" block="never" message="You may not break the extra loot chests!"/>
     <apply region="bases" block-place="never" block-break="only-iron" message="You can only break iron blocks in the bases!"/>
-    <apply block="no-void" message="You may not modify in this area!">
+    <apply block="deny(void)" message="You may not modify in this area!">
         <region>
             <complement id="void-area">
                 <negative>
@@ -129,7 +127,7 @@
         </region>
     </apply>
 </regions>
-<cores material="obsidian" leak="5">
+<cores material="obsidian" leak="5" mode-changes="true">
     <core team="cyan" region="cyan-core"/>
     <core team="purple" region="purple-core"/>
 </cores>
@@ -155,6 +153,10 @@
         </region>
     </destroyable>
 </destroyables>
+<modes>
+    <mode after="15m" material="gold block"/>
+    <mode after="20m" material="glass"/>
+</modes>
 <toolrepair>
     <tool>iron sword</tool>
     <tool>bow</tool>
@@ -178,11 +180,6 @@
     <item>sapling</item>
     <item>golden apple</item>
 </itemremove>
-<kill-rewards>
-    <kill-reward>
-        <item material="golden apple"/>
-    </kill-reward>
-</kill-rewards>
 <timelock>on</timelock>
 <maxbuildheight>26</maxbuildheight>
 </map>

--- a/dtcm/temple_valley/map.xml
+++ b/dtcm/temple_valley/map.xml
@@ -1,7 +1,8 @@
-<map proto="1.4.2">
+<map proto="1.5.0">
 <name>Temple Valley</name>
-<version>1.1.6</version>
+<version>1.1.7</version>
 <objective>Leak the enemies core above their central temple.</objective>
+<include id="gapple-kill-reward"/>
 <authors>
     <author uuid="e8d1ad63-bd9e-4d0e-9a6c-27f2b047d924"/> <!-- Mikeg542 -->
 </authors>
@@ -31,19 +32,19 @@
 </kits>
 <spawns>
     <spawn team="purple" kit="spawn-kit">
-        <regions>
+        <region>
             <cylinder base="194,33,9" height="0" radius="3"/>
-        </regions>
+        </region>
     </spawn>
     <spawn team="orange" kit="spawn-kit" yaw="180">
-        <regions>
+        <region>
             <cylinder base="-136,33,141" height="0" radius="3"/>
-        </regions>
+        </region>
     </spawn>
     <default>
-        <regions>
+        <region>
             <cylinder base="28.5,78,-49.5" height="0" radius="6"/>
-        </regions>
+        </region>
     </default>
 </spawns>
 <filters>
@@ -95,7 +96,7 @@
     <apply region="team-spawns" block="never" message="You may not modify the team spawns!"/>
     <apply region="playable-inverse" block="never" message="You may not modify outside of the playing field!"/>
 </regions>
-<cores leak="5">
+<cores leak="5" mode-changes="true">
     <core team="purple">
         <region>
             <cuboid min="190,66,81" max="196,72,87"/>
@@ -107,6 +108,10 @@
         </region>
     </core>
 </cores>
+<modes>
+    <mode after="15m" material="gold block"/>
+    <mode after="20m" material="glass"/>
+</modes>
 <toolrepair>
     <tool>iron sword</tool>
     <tool>bow</tool>
@@ -125,10 +130,5 @@
     <item>obsidian</item>
     <item>gold block</item>
 </itemremove>
-<kill-rewards>
-    <kill-reward>
-    	<item material="golden apple"/>
-    </kill-reward>
-</kill-rewards>
 <maxbuildheight>84</maxbuildheight>
 </map>

--- a/dtcm/total_war/map.xml
+++ b/dtcm/total_war/map.xml
@@ -1,7 +1,8 @@
-<map proto="1.4.2">
+<map proto="1.5.0">
 <name>Total War</name>
-<version>2.0.12</version>
+<version>2.0.13</version>
 <objective>Leak lava from each of the enemy's obsidian core 3 blocks downwards</objective>
+<include id="gapple-kill-reward"/>
 <authors>
     <author uuid="5986da63-a546-49c5-812d-d5c41a42510a"/> <!-- Lyzak -->
 </authors>
@@ -69,7 +70,7 @@
     <apply region="spawns" block="never"/>
     <apply region="playable-inverse" block="never" message="You may not build outside the playable region!"/>
 </regions>
-<cores leak="3">
+<cores leak="3" mode-changes="true">
     <cores team="red">
         <core name="Rear Core">
             <region>
@@ -95,6 +96,10 @@
         </core>
     </cores>
 </cores>
+<modes>
+    <mode after="15m" material="gold block"/>
+    <mode after="20m" material="glass"/>
+</modes>
 <itemremove>
     <item>seeds</item>
     <item>golden carrot</item>
@@ -111,10 +116,5 @@
     <tool>iron pickaxe</tool>
     <tool>iron axe</tool>
 </toolrepair>
-<kill-rewards>
-    <kill-reward>
-        <item material="golden apple"/>
-    </kill-reward>
-</kill-rewards>
 <maxbuildheight>58</maxbuildheight>
 </map>

--- a/other/newstalgia/medieval_clayfare/map.xml
+++ b/other/newstalgia/medieval_clayfare/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.5.0">
 <name>Medieval Clayfare</name>
-<version>1.6.11</version>
+<version>1.6.12</version>
 <objective>Leak lava from the enemy's obsidian core.</objective>
 <authors>
     <author uuid="c1ea235d-4224-46e4-ba4a-638838f6d039"/> <!-- Daffy_Duck01 -->
@@ -109,7 +109,7 @@
     <apply region="spawn" block="never"/>
     <apply region="outside-map" block="never" message="You may not build outside the map boundary!"/>
 </regions>
-<cores material="obsidian" leak="3">
+<cores material="obsidian" leak="3" mode-changes="true">
     <core team="blue">
         <region>
             <cuboid min="30,97,75" max="35,102,80"/>
@@ -121,6 +121,10 @@
         </region>
     </core>
 </cores>
+<modes>
+    <mode after="15m" material="gold block"/>
+    <mode after="20m" material="glass"/>
+</modes>
 <itemremove>
     <item>shears</item>
 </itemremove>


### PR DESCRIPTION
DTC maps made before proto 1.3.2 had two modes: gold block at 15 minutes and glass at 20 minutes. I've included the XML snippet below for more maps that may need it.
```xml
<!-- Don't forget mode-changes="true" in cores module -->
<modes>
    <mode after="15m" material="gold block"/>
    <mode after="20m" material="glass"/>
</modes>
```

Other than that, I've updated them for 1.5.0 standards. ~~I have not tested these maps, so I will do it as soon as possible.~~