### PR TITLE
Fix Rocketship Reduxed Jumpads Regions for Directrix + Variants

### DIFF
--- a/ctf/directrix/map.xml
+++ b/ctf/directrix/map.xml
@@ -301,10 +301,10 @@
         <union id="jump-pads">
             <union id="team-1-redux-jump-pads">
                 <cuboid id="team-1-to-platform" min="-51,29,-22" max="-50,31,-19"/>
-                <cuboid id="team-1-rocket-to-lower" min="36,28,22" max="35,30,20"/>
+                <cuboid id="team-1-rocket-to-lower" min="35.5,28,22" max="34,28.5,20"/>
             </union>
             <union id="team-2-redux-jump-pads">
-                <cuboid id="team-2-rocket-to-lower" min="-53,28,101" max="-52,30,103"/>
+                <cuboid id="team-2-rocket-to-lower" min="-52.5,28,101" max="-51,28.5,103"/>
                 <cuboid id="team-2-to-platform" min="34,29,145" max="32,31,142"/>
             </union>
         </union>

--- a/ctf/directrix/map.xml
+++ b/ctf/directrix/map.xml
@@ -5,7 +5,7 @@
 <variant id="classic" world="classic" slug="directrix">Classic</variant>
 <variant id="king_ranch" world="king_ranch" override="true">King Ranch</variant>
 <variant id="king_ranch_og" world="king_ranch_og" override="true">King Ranch: OG</variant>
-<version>2.0.7</version>
+<version>2.0.8</version>
 <gamemode>ctf</gamemode>
 <gamemode>rage</gamemode>
 <if variant="default">


### PR DESCRIPTION
Currently the jump-pads on directrix and in the XML are listed to jump players downwards towards the enemies spawns like this:
https://github.com/user-attachments/assets/97559203-8571-4dee-bb86-eb234eabe8f9
_Note that there are already at least 2 faster ways to get to that jump-pad without using the rocket-ship route_

However when jumping onto the end of the pad it produces a totally different result:
https://github.com/user-attachments/assets/c72cca2e-c1f9-4308-8b7b-d3ab8f1ab8d2
(Both Examples from TTie)

This is due to the fact that when running/walking onto the jump-pad only the player bonks their head on the blocks behind which are pictured in this overhead screenshot instead of the player being launched upward as the velocity applied in XML is intended to do.
![image](https://github.com/user-attachments/assets/3251f313-ac67-485f-a871-025c81606a8f)

With these proposed changes I've moved forward & made the jump pad height regions smaller so that the jump pad works consistently for running, walking & jumping and follows the intended trajectory.
https://github.com/user-attachments/assets/d71eb878-1408-41e6-bb60-ba912b771f66


