### PR TITLE
fix(raid_ffa): grant arrows on kill

### DIFF
--- a/ffa/raid_ffa/map.xml
+++ b/ffa/raid_ffa/map.xml
@@ -184,19 +184,21 @@
 <itemremove>
     <item>leather helmet</item>
 </itemremove>
-<if variant="guns">
-    <kill-rewards>
+<kill-rewards>
+    <unless variant="guns">
         <kill-reward>
             <item material="arrow"/>
         </kill-reward>
+    </unless>
+    <if variant="guns">
         <kill-reward>
             <filter>
                 <kill-streak count="2"/>
             </filter>
             <item material="fireball" amount="2" name="`fGrenade" projectile="grenade"/>
         </kill-reward>
-    </kill-rewards>
-</if>
+    </if>
+</kill-rewards>
 <disabledamage>
     <damage>fall</damage>
 </disabledamage>


### PR DESCRIPTION
An oversight made in https://github.com/OvercastCommunity/PublicMaps/commit/25ffda9619e831906469970490dcfedb73c882cf caused the default rage variant to not grant arrows on kill. This PR fixes the issue and grants the arrows correctly.