### PR TITLE
Winter Wars; Replace monument modes with fill actions

### DIFF
--- a/fun/blitz/winter_wars/map.xml
+++ b/fun/blitz/winter_wars/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.5.0" game="Blitz: Micro Battles">
 <name>Winter Wars</name>
-<version>1.0.3</version>
+<version>1.0.4</version>
 <created>2022-06-01</created>
 <objective>Four teams are divided onto the map and only one will remain. Gather blocks to help you build up a tower or barricade yourself. Watch out for the world border!</objective>
 <gamemode>arcade</gamemode>
@@ -24,9 +24,10 @@
 <time>170s</time>
 <broadcasts>
     <alert after="1s">`cFour teams are divided onto the map and only one will remain. Gather blocks to help you build up a tower or barricade yourself. Be careful for the world border!</alert>
-    <alert after="10s">`cThe walls have dropped. Take cover or attack!</alert>
-    <alert after="145s">`cThe ground is beginning to shake! Hurry and tower up to ensure you're the last one standing!</alert>
-    <alert after="155s">`cThe ground is about to give in! Get up high before it's too late! You have 10 seconds!</alert>
+    <alert after="10s">`cThe walls have fallen! Attack fast or take cover, the battle begins now!</alert>
+    <alert after="75s">`cThe world border is getting closer, be careful!</alert>
+    <alert after="145s">`cThe ground trembles beneath you! Scale to safety or fight before it's too late!</alert>
+    <alert after="155s">`cThe floor is collapsing! Climb higher, you've got 10 seconds to secure your victory!</alert>
     <alert after="165s">`cThe floor crumbles.</alert>
 </broadcasts>
 <!-- Blitz -->
@@ -48,16 +49,6 @@
         <boots unbreakable="true" locked="true" team-color="true" material="leather boots"/>
     </kit>
 </kits>
-<!-- TODO: replace fake destroyables with fill actions -->
-<!-- Walls & Floor -->
-<destroyables required="false" show="false">
-    <destroyable name="Walls" owner="blue"  materials="glass" modes="walls-to-air" region="walls"/>
-    <destroyable name="Floor" owner="green" materials="lava;stationary lava;stone;stained clay" modes="floor-to-air" region="floor"/>
-</destroyables>
-<modes>
-    <mode id="walls-to-air" after="10s"  show-before="0" material="air"/>
-    <mode id="floor-to-air" after="165s" show-before="0" material="air"/>
-</modes>
 <!-- Block Drops -->
 <blockdrops>
     <rule>
@@ -71,14 +62,34 @@
 </blockdrops>
 <!-- Filters -->
 <filters>
+    <!-- Walls & Floor -->
+    <after id="walls-to-air" duration="10s" message="Walls will fall in {0}">
+        <match-started/>
+    </after>
+    <after id="floor-to-air" duration="165s" message="Floor will crumble in {0}">
+        <match-started/>
+    </after>
     <not id="not-glass">
         <material>glass</material>
     </not>
 </filters>
+<actions>
+    <trigger scope="match" filter="walls-to-air">
+        <action>
+            <fill region="first-wall" material="air"/>
+            <fill region="second-wall" material="air"/>
+        </action>
+    </trigger>
+    <trigger scope="match" filter="floor-to-air">
+        <action>
+            <fill region="floor" material="air"/>
+        </action>
+    </trigger>
+</actions>
 <!-- Regions -->
 <regions>
     <!-- Definitions -->
-    <cuboid id="floor" min="2,0,-2" max="-2,40,-2"/>
+    <cuboid id="floor" min="-0.5,0,-0.5" max="1.5,34,1.5"/>
     <union id="walls">
         <cuboid id="first-wall" min="1,22,21" max="-1,37,-21"/>
         <cuboid id="second-wall" min="21,22,-1" max="-21,37,1"/>


### PR DESCRIPTION
- Replaced Monument Modes with Fill Actions.
- Fixed an issue where the floor did not crumble successfully at the end of the match due to incorrect coordinates.
- Added an alert to warn players about the world border.
- Updated map version from 1.0.3 to 1.0.4.