### PR TITLE
Arabia; 1.3.3 - Fix very strange bug

### DIFF
--- a/ctw/arabia/map.xml
+++ b/ctw/arabia/map.xml
@@ -197,8 +197,7 @@
     </rule>
 </block-drops>
 <itemkeep>
-    <item>wood:1</item>
-    <item>wood:2</item>
+    <item>wood</item>
     <item>glass</item>
     <item>golden apple</item>
     <item>water bucket</item>

--- a/ctw/arabia/map.xml
+++ b/ctw/arabia/map.xml
@@ -83,18 +83,7 @@
     </spawn>
 </spawns>
 <filters>
-    <not id="team-1-in-wr">
-        <any>
-            <team>team-2</team>
-            <material>chest</material>
-        </any>
-    </not>
-    <not id="team-2-in-wr">
-        <any>
-            <team>team-1</team>
-            <material>chest</material>
-        </any>
-    </not>
+    <material id="chest">chest</material>
     <all id="only-gold-regen">
         <material id="only-gold">gold block</material>
         <cause>world</cause>
@@ -125,12 +114,15 @@
         <region id="gold"/>
         <region id="wool-rooms"/>
     </complement>
+    <apply use="deny(team-2)" region="team-2-wool-rooms"/>
+    <apply use="deny(team-1)" region="team-1-wool-rooms"/>
     <apply enter="deny(team-2)" region="team-1-spawn" message="You may not enter the enemy's spawn!"/>
     <apply enter="deny(team-1)" region="team-2-spawn" message="You may not enter the enemy's spawn!"/>
     <apply enter="deny(team-2)" region="team-2-wool-rooms" message="You may not enter your team's wool rooms!"/>
     <apply enter="deny(team-1)" region="team-1-wool-rooms" message="You may not enter your team's wool rooms!"/>
-    <apply block="team-1-in-wr" use="deny(team-2)" region="team-2-wool-rooms"/>
-    <apply block="team-2-in-wr" use="deny(team-1)" region="team-1-wool-rooms"/>
+    <apply block="deny(chest)" region="wool-rooms" message="You may not break or place this block in the wool rooms!"/>
+    <apply block="deny(team-2)" region="team-2-wool-rooms" message="You may not interfere with your team's own wool rooms!"/>
+    <apply block="deny(team-1)" region="team-1-wool-rooms" message="You may not interfere with your team's own wool rooms!"/>
     <apply block-break="only-gold" block-place="only-gold-regen" region="gold" message="You may only break gold blocks here!"/>
     <apply block="deny(void)" region="void-area" message="You may not edit the void area!"/>
 </regions>
@@ -183,19 +175,6 @@
         <item>snow ball</item>
     </if>
 </itemremove>
-<block-drops>
-    <rule>
-        <filter>
-            <any>
-                <material>wood</material>
-                <material>glass</material>
-            </any>
-        </filter>
-        <drops>
-            <item chance="0" material="glass"/>
-        </drops>
-    </rule>
-</block-drops>
 <itemkeep>
     <item>wood</item>
     <item>glass</item>

--- a/ctw/arabia/map.xml
+++ b/ctw/arabia/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.5.0">
 <name>Arabia</name>
-<version>1.3.2</version>
+<version>1.3.3</version>
 <variant id="halloween" world="halloween" override="true">AraBOOia</variant>
 <variant id="christmas" world="christmas" override="true">AraBlizzardia</variant>
 <include id="gapple-kill-reward"/>
@@ -16,7 +16,6 @@
 </if>
 <if variant="halloween,christmas">
     <constant id="wood-type">1</constant>
-
 </if>
 <authors>
     <author uuid="b8add1ba-8e13-4673-bc73-4e3ed524d40e"/> <!-- Blazy36 -->
@@ -86,13 +85,13 @@
 <filters>
     <not id="team-1-in-wr">
         <any>
-            <team id="only-team-2">team-2</team>
+            <team>team-2</team>
             <material>chest</material>
         </any>
     </not>
     <not id="team-2-in-wr">
         <any>
-            <team id="only-team-1">team-1</team>
+            <team>team-1</team>
             <material>chest</material>
         </any>
     </not>
@@ -126,12 +125,12 @@
         <region id="gold"/>
         <region id="wool-rooms"/>
     </complement>
-    <apply enter="only-team-1" region="team-1-spawn" message="You may not enter the enemy's spawn!"/>
-    <apply enter="only-team-2" region="team-2-spawn" message="You may not enter the enemy's spawn!"/>
-    <apply enter="only-team-1" region="team-2-wool-rooms" message="You may not enter your team's wool rooms!"/>
-    <apply enter="only-team-2" region="team-1-wool-rooms" message="You may not enter your team's wool rooms!"/>
-    <apply block="team-1-in-wr" use="only-team-1" region="team-2-wool-rooms"/>
-    <apply block="team-2-in-wr" use="only-team-2" region="team-1-wool-rooms"/>
+    <apply enter="deny(team-2)" region="team-1-spawn" message="You may not enter the enemy's spawn!"/>
+    <apply enter="deny(team-1)" region="team-2-spawn" message="You may not enter the enemy's spawn!"/>
+    <apply enter="deny(team-2)" region="team-2-wool-rooms" message="You may not enter your team's wool rooms!"/>
+    <apply enter="deny(team-1)" region="team-1-wool-rooms" message="You may not enter your team's wool rooms!"/>
+    <apply block="team-1-in-wr" use="deny(team-2)" region="team-2-wool-rooms"/>
+    <apply block="team-2-in-wr" use="deny(team-1)" region="team-1-wool-rooms"/>
     <apply block-break="only-gold" block-place="only-gold-regen" region="gold" message="You may only break gold blocks here!"/>
     <apply block="deny(void)" region="void-area" message="You may not edit the void area!"/>
 </regions>
@@ -198,9 +197,11 @@
     </rule>
 </block-drops>
 <itemkeep>
-    <item>wood</item>
+    <item>wood:1</item>
+    <item>wood:2</item>
     <item>glass</item>
     <item>golden apple</item>
+    <item>water bucket</item>
 </itemkeep>
 <kill-rewards>
     <kill-reward>


### PR DESCRIPTION
- Simplified team ID references to utilize proto 1.5 improvements, eliminating redundant filter definitions.
- Added water bucket, wood:1 & wood:2 to itemkeep.

For some strange reason, birch planks (wood:2) don’t behave like other wood types. If you just specify `wood` in `itemkeep` or `itemremove`, birch will not be accounted for and will still drop on death, but every other type (oak, spruce, etc.) works fine. I've tested this on multiple maps, and still getting the same issue.

The fix for now is explicitly specifying `wood:2` in `itemkeep`, But someone should probably dig deeper, maybe this is an oversight on my part?

The changes above have also been tested on a private local testing server to ensure compatibility.