### PR TITLE
Palm Rust: Change obsidian break time from 4.2s to 5.8s

### DIFF
--- a/dtcm/palm_rust/map.xml
+++ b/dtcm/palm_rust/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.5.0">
 <name>Palm Rust</name>
-<version>2.2.3</version>
+<version>2.2.4</version>
 <objective>Destroy the enemy team's monuments!</objective>
 <gamemode>dtm</gamemode>
 <include id="gapple-kill-reward"/>
@@ -17,7 +17,7 @@
     <kit id="spawn-kit">
         <item slot="0" material="iron sword"/>
         <item slot="1" enchantment="arrow infinite" material="bow"/>
-        <item slot="2" enchantment="dig speed:3;durability:3" material="diamond pickaxe"/>
+        <item slot="2" enchantment="dig speed:2;durability:3" material="diamond pickaxe"/>
         <item slot="3" material="iron spade"/>
         <item slot="4" amount="2" material="golden apple"/>
         <item slot="5" amount="64" material="log"/>


### PR DESCRIPTION
Over the years, this map has usually been rushed very quickly - by the time someone finishes crafting armor, the obsidian can already broken due to a 4 second break-time (3.5 seconds with enabled beacon). Majority of matches on this map are averaging somewhere around 6 mins.

I'd like to give it a shot to up the time to 5.8s by downgrading the efficiency - if this ends up backfiring, we can change it back. But measuring the blocks to distance in singleplayer, this change should be fine.