### PR TITLE
Citadel: 1.3.9

### DIFF
--- a/ctw/citadel/map.xml
+++ b/ctw/citadel/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.5.0">
 <name>Citadel</name>
-<version>1.3.8</version>
+<version>1.3.9</version>
 <objective>Attackers must capture the wool before the time limit runs out</objective>
 <gamemode>ctw</gamemode>
 <gamemode>ad</gamemode>
@@ -44,14 +44,14 @@
         <item slot="1" material="bow"/>
         <item slot="2" unbreakable="true" material="stone pickaxe"/>
         <item slot="3" material="stone spade"/>
-        <item slot="4" amount="54" damage="14" material="stained clay"/>
-        <item slot="5" amount="24" damage="14" material="stained glass"/>
+        <item slot="4" amount="54" team-color="true" material="stained clay"/>
+        <item slot="5" amount="24" team-color="true" material="stained glass"/>
         <item slot="6" amount="48" material="vine"/>
         <item slot="33" material="boat"/>
         <item slot="28" amount="24" material="arrow"/>
         <helmet locked="true" unbreakable="true" enchantment="protection projectile" material="iron helmet"/>
-        <chestplate locked="true" unbreakable="true" enchantment="protection explosions:6" color="CD0000" material="leather chestplate"/>
-        <leggings locked="false" unbreakable="true" color="CD0000" material="leather leggings"/>
+        <chestplate locked="true" unbreakable="true" enchantment="protection explosions:6" team-color="true" material="leather chestplate"/>
+        <leggings locked="false" unbreakable="true" team-color="true" material="leather leggings"/>
         <boots locked="true" unbreakable="true" enchantment="protection fall" material="iron boots"/>
         <effect duration="3">speed</effect>
     </kit>
@@ -61,13 +61,13 @@
         <item slot="2" unbreakable="true" enchantment="dig speed" material="iron pickaxe"/>
         <item slot="3" unbreakable="true" enchantment="dig speed" material="iron spade"/>
         <item slot="30" unbreakable="true" material="iron axe"/>
-        <item slot="4" amount="64" damage="11" material="stained clay"/>
+        <item slot="4" amount="64" team-color="true" material="stained clay"/>
         <item slot="5" amount="16" material="wood"/>
-        <item slot="6" amount="32" damage="11" material="stained glass"/>
+        <item slot="6" amount="32" team-color="true" material="stained glass"/>
         <item slot="24" amount="42" material="arrow"/>
         <helmet locked="true" unbreakable="true" enchantment="protection projectile" material="iron helmet"/>
-        <chestplate locked="true" unbreakable="true" enchantment="protection explosions:6" color="334cb2" material="leather chestplate"/>
-        <leggings locked="true" unbreakable="true" color="334CB2" material="leather leggings"/>
+        <chestplate locked="true" unbreakable="true" enchantment="protection explosions:6" team-color="true" material="leather chestplate"/>
+        <leggings locked="true" unbreakable="true" team-color="true" material="leather leggings"/>
         <boots locked="true" unbreakable="true" material="iron boots"/>
         <effect duration="12">speed</effect>
     </kit>
@@ -201,14 +201,17 @@
         <item material="tnt"/>
         <item amount="8" material="arrow"/>
         <item damage="8229" name="`cHealth Kit" material="potion"/>
-        <item amount="16" damage="14" material="stained clay"/>
+        <item amount="16" team-color="true" material="stained clay"/>
     </kill-reward>
     <kill-reward filter="defenders">
         <item damage="8261" name="`cHealth Kit" material="potion"/>
         <item amount="7" material="arrow"/>
-        <item amount="8" damage="11" material="stained clay"/>
+        <item amount="8" team-color="true" material="stained clay"/>
     </kill-reward>
 </kill-rewards>
+<itemkeep>
+    <item>golden apple</item>
+</itemkeep>
 <itemremove>
     <item>leather helmet</item>
     <item>leather chestplate</item>


### PR DESCRIPTION
- Used the `team-color` attribute for armor and blocks in the spawn kit instead of the `damage` attribute.
- Added golden apple to itemkeep.