### PR TITLE
Grassy Mound: 1.0.2

### DIFF
--- a/dtcm/grassy_mound/map.xml
+++ b/dtcm/grassy_mound/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Grassy Mound</name>
-<version>1.0.1</version>
+<version>1.0.2</version>
+<include id="gapple-kill-reward"/>
 <objective>Destroy the other team's Gold monument!</objective>
 <authors>
     <author uuid="f690a591-348b-482e-a18d-7779d0c0a28c" /> <!-- mitchiii_ -->
@@ -18,13 +19,13 @@
         <item slot="3" unbreakable="true" material="stone axe"/>
         <item slot="4" amount="24" material="wood"/>
         <item slot="5" amount="32" team-color="true" material="stained clay"/>
-        <item slot="7" amount="24" material="arrow"/>
-        <item slot="8" amount="64" material="golden carrot"/>
+        <item slot="6" material="golden apple"/>
+        <item slot="8" amount="24" material="arrow"/>
         <helmet unbreakable="true" team-color="true" material="leather helmet"/>
         <chestplate unbreakable="true" material="chainmail chestplate"/>
         <leggings unbreakable="true" team-color="true" material="leather leggings"/>
         <boots unbreakable="true" team-color="true" material="leather boots"/>
-        <effect duration="3" amplifier="10">resistance</effect>
+        <effect duration="3" amplifier="5">resistance</effect>
     </kit>
 </kits>
 <spawns>
@@ -46,30 +47,19 @@
 </spawns>
 <respawn delay="3s"/>
 <filters>
-    <not id="void-break-ban">
-        <any>
-            <material>web</material>
-        </any>
-    </not>
-    <not id="deny-player-cause">
-        <cause>player</cause>
-    </not>
-    <not id="deny-enchant-break">
-        <material>enchantment table</material>
-    </not>
+    <material id="void-break">web</material>
+    <material id="enchant-table">enchantment table</material>
 </filters>
 <regions>
     <union id="team-spawns">
         <cuboid id="blue-spawn" min="32,0,286" max="42,oo,273"/>
         <cuboid id="red-spawn"  min="111,0,169" max="101,oo,182"/>
     </union>
-    <above id="world-limit" y="23"/>
     <apply region="blue-spawn" enter="blue-team" message="You may not enter the enemy's spawn"/>
     <apply region="red-spawn" enter="red-team" message="You may not enter the enemy's spawn"/>
     <apply region="team-spawns" block="never" message="You may not modify the spawn area"/>
-    <apply region="world-limit" block-place="deny-player-cause" message="You may not place blocks that high"/>
-    <apply block-place="deny(void)" block-break="void-break-ban" message="You may not interact with that material here"/>
-    <apply block="deny-enchant-break" message="You may not break the enchantment table"/>
+    <apply block-place="deny(void)" block-break="deny(void-break)" message="You may not interact with that material here"/>
+    <apply block="deny(enchant-table)" message="You may not break the enchantment table"/>
 </regions>
 <destroyables materials="gold block" mode-changes="true">
     <destroyable id="blue-monument" name="Monument" owner="blue-team">
@@ -90,7 +80,6 @@
     <kill-reward>
         <item amount="6" material="wood"/>
         <item amount="8" material="arrow"/>
-        <item material="golden apple"/>
         <item amount="2" material="exp bottle"/>
         <item amount="6" team-color="true" material="stained clay"/>
     </kill-reward>
@@ -99,7 +88,6 @@
             <kill-streak count="6" repeat="false"/>
         </filter>
         <item damage="61" material="flint and steel"/>
-        <item material="golden apple"/>
         <item amount="2" material="exp bottle"/>
     </kill-reward>
     <kill-reward>
@@ -139,16 +127,22 @@
             <material>gold chestplate</material>
         </match>
         <modify>
-            <enchantment level="1">protection</enchantment>
+            <enchantment>protection</enchantment>
         </modify>
     </rule>
 </item-mods>
+<toolrepair>
+    <tool>stone sword</tool>
+    <tool>bow</tool>
+    <tool>stone pickaxe</tool>
+    <tool>stone axe</tool>
+</toolrepair>
+<itemkeep>
+    <item>golden apple</item>
+    <item>stained clay</item>
+    <item>wood</item>
+</itemkeep>
 <itemremove>
-    <item>stone sword</item>
-    <item>bow</item>
-    <item>stone pickaxe</item>
-    <item>stone axe</item>
-    <item>golden carrot</item>
     <item>leather helmet</item>
     <item>chainmail chestplate</item>
     <item>leather leggings</item>
@@ -158,4 +152,8 @@
     <item>coal block</item>
     <item>string</item>
 </itemremove>
+<hunger>
+    <depletion>off</depletion>
+</hunger>
+<maxbuildheight>23</maxbuildheight>
 </map>


### PR DESCRIPTION
- Replaced golden apple kill reward with gapple include.
- Swapped the golden carrot for a golden apple in the main kit and adjusted item slot positions accordingly.
- Reduced resistance amplifier in the kit from 10 to 5. (the max is 5)
- Simplified filters for better efficiency.
- Replaced build height regions with the `maxbuildheight` module (previous method was unnecessarily complex).
- Introduced `toolrepair` and `itemkeep`
- Added arrow, golden apple, wood, and stained clay to `itemkeep`
- Disabled hunger.

And as per usual, the changes above have been tested on a local PGM server to ensure compatibility.