### PR TITLE
Wild West: 1.0.2

### DIFF
--- a/dtcm/wild_west/map.xml
+++ b/dtcm/wild_west/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.5.1">
 <name>Wild West</name>
-<version>1.0.1</version>
+<version>1.0.2</version>
 <objective>Leak the lava from the enemy's core.</objective>
 <created>2016-10-28</created>
 <phase>development</phase>
@@ -18,13 +18,13 @@
         <clear/>
         <item slot="0" unbreakable="true" material="iron sword"/>
         <item slot="1" unbreakable="true" material="bow"/>
-        <item slot="2" unbreakable="true" enchantment="efficiency" material="diamond pickaxe"/>
+        <item slot="2" unbreakable="true" material="diamond pickaxe"/>
         <item slot="3" unbreakable="true" material="iron axe"/>
-        <item slot="4" amount="64" material="wood"/>
-        <item slot="5" amount="16" material="glass"/>
+        <item slot="4" unbreakable="true" material="iron spade"/>
+        <item slot="5" amount="64" material="wood"/>
+        <item slot="6" amount="16" material="glass"/>
         <item slot="8" material="golden apple"/>
         <item slot="28" amount="64" material="arrow"/>
-        <item slot="30" unbreakable="true" material="iron spade"/>
         <helmet unbreakable="true" material="iron helmet"/>
         <chestplate unbreakable="true" team-color="true" material="leather chestplate"/>
         <leggings unbreakable="true" team-color="true" material="leather leggings"/>
@@ -52,6 +52,9 @@
 <filters>
     <material id="only-iron">iron block</material>
     <material id="only-air">air</material>
+    <carrying id="eff-carrying-lvl-0" ignore-metadata="true" ignore-enchantments="false">
+        <item material="diamond pickaxe"/>
+    </carrying>
     <carrying id="eff-carrying-lvl-1" ignore-metadata="true" ignore-enchantments="false">
         <item material="diamond pickaxe" enchantment="efficiency:1"/>
     </carrying>
@@ -76,7 +79,7 @@
     <time id="after-45m">45m</time>
 </filters>
 <variables>
-    <variable id="eff_level" scope="match" default="1"/>
+    <variable id="eff_level" scope="match"/>
 </variables>
 <actions>
     <action id="activate-eff-mode" scope="player" expose="true">
@@ -85,12 +88,12 @@
         </enchant-item>
     </action>
     <action id="deactivate-eff-mode" scope="player" expose="true">
-        <enchant-item enchantment="efficiency" level="1" ignore-metadata="true">
+        <enchant-item enchantment="efficiency" level="0" ignore-metadata="true">
             <find material="diamond pickaxe"/>
         </enchant-item>
     </action>
-    <trigger scope="player" filter="all(efficiency-filter,any(all(not(eff_level=1),eff-carrying-lvl-1),all(not(eff_level=2),eff-carrying-lvl-2),all(not(eff_level=3),eff-carrying-lvl-3)))" action="activate-eff-mode"/>
-    <trigger scope="player" filter="all(not(efficiency-filter),any(eff-carrying-lvl-2,eff-carrying-lvl-3))" action="deactivate-eff-mode"/>
+    <trigger scope="player" filter="all(efficiency-filter,any(all(not(eff_level=0),eff-carrying-lvl-0),all(not(eff_level=1),eff-carrying-lvl-1),all(not(eff_level=2),eff-carrying-lvl-2),all(not(eff_level=3),eff-carrying-lvl-3)))" action="activate-eff-mode"/>
+    <trigger scope="player" filter="all(not(efficiency-filter),any(eff-carrying-lvl-1,eff-carrying-lvl-2,eff-carrying-lvl-3))" action="deactivate-eff-mode"/>
     <set id="eff-increase-level" var="eff_level" value="eff_level+1" scope="match"/>
 </actions>
 <regions>
@@ -121,8 +124,9 @@
     <core team="blue-team" region="blue-core"/>
 </cores>
 <modes>
-    <mode name="`dEfficiency II`3 near the `6cores" action="eff-increase-level" after="15m"/>
-    <mode name="`dEfficiency III`3 near the `6cores" action="eff-increase-level" after="30m"/>
+    <mode name="`dEfficiency I`3 near the `6cores" action="eff-increase-level" after="15m"/>
+    <mode name="`dEfficiency II`3 near the `6cores" action="eff-increase-level" after="30m"/>
+    <mode name="`dEfficiency III`3 near the `6cores" action="eff-increase-level" after="45m"/>
 </modes>
 <renewables>
     <renewable region="map" renew-filter="only-iron" replace-filter="only-air"/>
@@ -157,12 +161,14 @@
     </kill-reward>
 </kill-rewards>
 <maxbuildheight>35</maxbuildheight>
+<!-- try without respawn delays
 <respawns>
-    <respawn delay="3s" filter="not(after-15m)"/>
-    <respawn delay="3.2s" filter="all(after-15m,not(after-30m))"/>
-    <respawn delay="3.5s" filter="all(after-30m,not(after-45m))"/>
-    <respawn delay="4s" filter="after-45m"/>
+    <respawn delay="2s" filter="not(after-15m)"/>
+    <respawn delay="2.2s" filter="all(after-15m,not(after-30m))"/>
+    <respawn delay="2.5s" filter="all(after-30m,not(after-45m))"/>
+    <respawn delay="3s" filter="after-45m"/>
 </respawns>
+-->
 <hunger>
     <depletion>off</depletion>
 </hunger>


### PR DESCRIPTION
All changes have been tested on local servers to ensure compatibility.
This update reflects playtest feedback.

- Move iron spade to hotbar
- Changes to help prevent stalemates have been relaxed
    - Remove the Efficiency enchantment from the diamond pickaxe in the spawn-kit
    - Add an Efficiency I stage at 15 minutes and move the Efficiency II and III stages to 30 and 45 minutes
    - Disable respawn delays

These changes were made with consideration for other maps such as Annealing III and Oakspell, where the spawn point and core are also close together.
I hope this update helps the map achieve a playtime that is neither too short nor too long.

The changes intended to help prevent stalemates may be strengthened again at any time based on gameplay feedback.